### PR TITLE
security: update base images to address vulnerability

### DIFF
--- a/az/Dockerfile
+++ b/az/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-cli:2.36.0
+FROM mcr.microsoft.com/azure-cli:2.40.0
 LABEL maintainer=acr-feedback@microsoft.com
 CMD [ "--version" ]
 ENTRYPOINT [ "az" ]

--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -1,2 +1,6 @@
-FROM bash:5.1
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 LABEL maintainer=acr-feedback@microsoft.com
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["bash"]

--- a/bash/docker-entrypoint.sh
+++ b/bash/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# first arg is `-f` or `--some-option`
+# or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	# docker run bash -c 'echo hi'
+	exec bash "$@"
+fi
+
+exec "$@"

--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:3.15
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 LABEL maintainer=acr-feedback@microsoft.com
-
-RUN apk add --no-cache curl
 
 ENTRYPOINT ["/usr/bin/curl"]


### PR DESCRIPTION
**Purpose of the PR**

- update bash/curl to be based on mariner:2.0
- update azure-cli to 2.40.0
