### PR TITLE
Adding cssc image to acr task command

### DIFF
--- a/cssc/Dockerfile
+++ b/cssc/Dockerfile
@@ -1,5 +1,7 @@
 ARG acr_version=0.11
-FROM mcr.microsoft.com/acr/acr-cli:$acr_version as build
+ARG oras_version=1.2.0
+FROM ghcr.io/oras-project/oras:v${oras_version} as oras
+FROM mcr.microsoft.com/acr/acr-cli:${acr_version} as build
 ARG copa_version=0.6.2
 ARG trivy_version=0.51.4
 RUN tdnf check-update \
@@ -12,6 +14,7 @@ RUN curl --retry 5 -fsSL -o copa.tar.gz https://github.com/project-copacetic/cop
 RUN cp /usr/bin/acr /tmp/bin/
 COPY docker-entrypoint.sh /tmp/bin/
 RUN chmod +x /tmp/bin/docker-entrypoint.sh
+COPY --from=oras /bin/oras /tmp/bin/
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 LABEL maintainer=acr-feedback@microsoft.com

--- a/cssc/Dockerfile
+++ b/cssc/Dockerfile
@@ -1,0 +1,23 @@
+ARG acr_version=0.11
+FROM mcr.microsoft.com/acr/acr-cli:$acr_version as build
+ARG copa_version=0.6.2
+ARG trivy_version=0.51.4
+RUN tdnf check-update \
+    && tdnf --refresh install -y \
+        tar
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp/bin v${trivy_version}
+RUN curl --retry 5 -fsSL -o copa.tar.gz https://github.com/project-copacetic/copacetic/releases/download/v${copa_version}/copa_${copa_version}_linux_amd64.tar.gz && \
+    tar -zxvf copa.tar.gz && \
+    cp copa /tmp/bin/
+RUN cp /usr/bin/acr /tmp/bin/
+
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+LABEL maintainer=acr-feedback@microsoft.com
+RUN tdnf check-update \
+    && tdnf --refresh install -y \
+        ca-certificates-microsoft \
+        moby-cli moby-containerd \
+    && tdnf clean all
+COPY --from=build /tmp/bin/ /usr/bin/
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/cssc/Dockerfile
+++ b/cssc/Dockerfile
@@ -10,6 +10,8 @@ RUN curl --retry 5 -fsSL -o copa.tar.gz https://github.com/project-copacetic/cop
     tar -zxvf copa.tar.gz && \
     cp copa /tmp/bin/
 RUN cp /usr/bin/acr /tmp/bin/
+COPY docker-entrypoint.sh /tmp/bin/
+RUN chmod +x /tmp/bin/docker-entrypoint.sh
 
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 LABEL maintainer=acr-feedback@microsoft.com
@@ -19,5 +21,4 @@ RUN tdnf check-update \
         moby-cli moby-containerd \
     && tdnf clean all
 COPY --from=build /tmp/bin/ /usr/bin/
-COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/cssc/README.md
+++ b/cssc/README.md
@@ -1,0 +1,15 @@
+# cssc
+
+This image is for cssc workflow commands and contains acr, trivy and copa
+
+## Building
+
+To build this image, run the following in this directory.
+
+```sh
+$ az acr run -f acb.yaml -r registryname /dev/null
+```
+
+## Usage
+
+Refer to the [acb.yaml](./acb.yaml) file for example usage.

--- a/cssc/README.md
+++ b/cssc/README.md
@@ -1,6 +1,6 @@
 # cssc
 
-This image is for cssc workflow commands and contains acr, trivy and copa
+This image is for cssc workflow commands and contains acr, oras, trivy and copa
 
 ## Building
 

--- a/cssc/acb.yaml
+++ b/cssc/acb.yaml
@@ -1,0 +1,10 @@
+version: v1.1.0
+
+steps:
+  # Build the image
+  - build: -f Dockerfile -t {{.Run.Registry}}/cssc .
+
+  - cmd: {{.Run.Registry}}/cssc acr --help
+
+  # Push the image
+  - push: ["{{.Run.Registry}}/cssc"]

--- a/cssc/docker-entrypoint.sh
+++ b/cssc/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# first arg is `-f` or `--some-option`
+# or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	# docker run bash -c 'echo hi'
+	exec bash "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This pull request introduces a new Docker image for cssc workflow commands, which includes acr, oras, trivy, and copa. This will provide single image with all cssc cli which can be cached and will improve the performance of cssc task. The `Dockerfile` has been updated to build this image, and a `README.md` file has been added to explain how to build and use the image. The `acb.yaml` file outlines the steps for building and pushing the image, and a `docker-entrypoint.sh` script has been added to handle command execution within the Docker container.

Docker image creation and configuration:

* [`cssc/Dockerfile`](diffhunk://#diff-8d47beb83754f738d31c3b3849e01e011da44e6fca0955bbaac2b28efb5a89e7R1-R27): Updated to build a new Docker image that includes acr, oras, trivy, and copa. The Dockerfile includes instructions for downloading and installing these tools, copying them into the Docker image, and setting the entrypoint for the Docker container.

Documentation:

* [`cssc/README.md`](diffhunk://#diff-b96460a7fe90771aebe2ee993409a0787a4dfa35af8727bdc4b7c9bd0f18267eR1-R15): Added a new file to explain how to build and use the new Docker image for cssc workflow commands.

Build and push process:

* [`cssc/acb.yaml`](diffhunk://#diff-51d78f8000089c4f5f1140179b387c5c6528941323a9f8ce89c3dd73b71d3616R1-R10): Added a new file to outline the steps for building and pushing the Docker image.

Docker container execution:

* [`cssc/docker-entrypoint.sh`](diffhunk://#diff-9ee3f21cf883205a79858eb3bab3d83acf598106166e09bccfb76efa36825911R1-R11): Added a new script to handle command execution within the Docker container. The script checks if the first argument is a flag or if there are no arguments, and in these cases, it executes bash with the provided arguments. Otherwise, it executes the provided command. 
