### PR TITLE
Reusing acr-cli base layer

### DIFF
--- a/cssc/Dockerfile
+++ b/cssc/Dockerfile
@@ -1,22 +1,18 @@
 ARG acr_version=0.11
 ARG oras_version=1.2.0
-FROM ghcr.io/oras-project/oras:v${oras_version} as oras
-FROM mcr.microsoft.com/acr/acr-cli:${acr_version} as build
+FROM ghcr.io/oras-project/oras:v${oras_version} as build
 ARG copa_version=0.6.2
 ARG trivy_version=0.51.4
-RUN tdnf check-update \
-    && tdnf --refresh install -y \
-        tar
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp/bin v${trivy_version}
+RUN apk add curl tar gzip
+RUN curl --retry 5 -fsSL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp/bin v${trivy_version}
 RUN curl --retry 5 -fsSL -o copa.tar.gz https://github.com/project-copacetic/copacetic/releases/download/v${copa_version}/copa_${copa_version}_linux_amd64.tar.gz && \
     tar -zxvf copa.tar.gz && \
     cp copa /tmp/bin/
-RUN cp /usr/bin/acr /tmp/bin/
 COPY docker-entrypoint.sh /tmp/bin/
-RUN chmod +x /tmp/bin/docker-entrypoint.sh
-COPY --from=oras /bin/oras /tmp/bin/
+RUN chmod +x /tmp/bin/docker-entrypoint.sh & cp /bin/oras /tmp/bin/
+ 
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/acr/acr-cli:${acr_version}
 LABEL maintainer=acr-feedback@microsoft.com
 RUN tdnf check-update \
     && tdnf --refresh install -y \

--- a/cssc/Dockerfile
+++ b/cssc/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer=acr-feedback@microsoft.com
 RUN tdnf check-update \
     && tdnf --refresh install -y \
         ca-certificates-microsoft \
-        moby-cli moby-containerd \
+        moby-cli moby-containerd jq\
     && tdnf clean all
 COPY --from=build /tmp/bin/ /usr/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
**Purpose of the PR**
This pull request includes changes to the `cssc/Dockerfile` to reuse layers from acr-cli

Here are the key changes:

* [`cssc/Dockerfile`](diffhunk://#diff-8d47beb83754f738d31c3b3849e01e011da44e6fca0955bbaac2b28efb5a89e7L3-R15): The base image for the `build` stage has been changed from `mcr.microsoft.com/acr/acr-cli:${acr_version}` to `ghcr.io/oras-project/oras:v${oras_version}`. This change eliminates the need to copy the `oras` binary from a separate stage.
* [`cssc/Dockerfile`](diffhunk://#diff-8d47beb83754f738d31c3b3849e01e011da44e6fca0955bbaac2b28efb5a89e7L3-R15): The final base image has been changed from `mcr.microsoft.com/cbl-mariner/base/core:2.0` to `mcr.microsoft.com/acr/acr-cli:${acr_version}`. This change may affect the final size and compatibility of the Docker image.
* `cssc/Dockerfile`: The `RUN` commands have been simplified and consolidated. The `tdnf` package manager commands have been removed, and the `apk` package manager is now used to install `curl`, `tar`, and `gzip`. The `curl` command to download `trivy` now includes a `--retry 5` flag for better reliability. The `chmod` and `cp` commands have been combined 