### PR TITLE
Update Trivy and Copa versions to latest in CSSC image

### DIFF
--- a/cssc/Dockerfile
+++ b/cssc/Dockerfile
@@ -1,8 +1,8 @@
 ARG acr_version=0.14
 ARG oras_version=1.2.0
 FROM ghcr.io/oras-project/oras:v${oras_version} as build
-ARG copa_version=0.6.2
-ARG trivy_version=0.57.0
+ARG copa_version=0.9.0
+ARG trivy_version=0.59.1
 ARG syft_version=1.11.1
 RUN apk add curl tar gzip
 RUN curl --retry 5 -fsSL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /tmp/bin v${syft_version}


### PR DESCRIPTION
Purpose of the PR

- Update Copa version in cssc image to enable support for patching Azure Linux 3 based images
- Update Trivy version to latest

Fixes #

- NA