### PR TITLE
Update cssc image with source-policy file for copa

### DIFF
--- a/cssc/Dockerfile
+++ b/cssc/Dockerfile
@@ -16,6 +16,8 @@ RUN chmod +x /tmp/bin/docker-entrypoint.sh & cp /bin/oras /tmp/bin/
 
 FROM mcr.microsoft.com/acr/acr-cli:${acr_version}
 LABEL maintainer=acr-feedback@microsoft.com
+ENV EXPERIMENTAL_BUILDKIT_SOURCE_POLICY="/app/source-policy.json"
+COPY source-policy.json /app/source-policy.json
 RUN tdnf check-update \
     && tdnf --refresh install -y \
         ca-certificates-microsoft \

--- a/cssc/source-policy.json
+++ b/cssc/source-policy.json
@@ -1,0 +1,22 @@
+{
+    "rules": [
+      {
+        "action": "CONVERT",
+        "selector": {
+          "identifier": "docker-image://docker.io/library/debian:*"
+        },
+        "updates": {
+          "identifier": "docker-image://mcr.microsoft.com/mirror/docker/library/debian:${1}"
+        }
+      },
+      {
+        "action": "CONVERT",
+        "selector": {
+          "identifier": "docker-image://docker.io/library/ubuntu:*"
+        },
+        "updates": {
+          "identifier": "docker-image://mcr.microsoft.com/mirror/docker/library/ubuntu:${1}"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
**Purpose of the PR**

This PR unblocks docker throttling during tooling image pull when copa patch happens by making use of the source policy file to use MCR instead.

Changes are:
- Updated cssc image with source-policy file for copa
- Sets env variable EXPERIMENTAL_BUILDKIT_SOURCE_POLICY for copa

Fixes #
- N/A