### PR TITLE
Updated acr cli, trivy and copa versions to latest available versions

### DIFF
--- a/cssc/Dockerfile
+++ b/cssc/Dockerfile
@@ -1,8 +1,8 @@
-ARG acr_version=0.14
+ARG acr_version=0.15
 ARG oras_version=1.2.0
 FROM ghcr.io/oras-project/oras:v${oras_version} as build
-ARG copa_version=0.9.0
-ARG trivy_version=0.59.1
+ARG copa_version=0.10.0
+ARG trivy_version=0.60.0
 ARG syft_version=1.11.1
 RUN apk add curl tar gzip
 RUN curl --retry 5 -fsSL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /tmp/bin v${syft_version}


### PR DESCRIPTION
**Purpose of the PR**
- Trivy updated to latest version - https://github.com/aquasecurity/trivy/tags
- Copa updated to latest version - https://github.com/project-copacetic/copacetic/tags
- Acr Cli updated to latest version to pick the fix for duplicate matching repo for cssc

Fixes #
- None