### PR TITLE
fix: bump trivy version to latest available version

### DIFF
--- a/cssc/Dockerfile
+++ b/cssc/Dockerfile
@@ -2,7 +2,7 @@ ARG acr_version=0.19
 ARG oras_version=1.2.0
 FROM ghcr.io/oras-project/oras:v${oras_version} as build
 ARG copa_version=0.10.0
-ARG trivy_version=0.60.0
+ARG trivy_version=0.69.3
 ARG syft_version=1.11.1
 RUN apk add curl tar gzip
 RUN curl --retry 5 -fsSL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /tmp/bin v${syft_version}


### PR DESCRIPTION
**Purpose of the PR**
- Previous pinned version of trivy got deleted as a part of their recent security incident, bumping to latest available version

Fixes #
- acr-task-command build fails because of unavailable trivy version